### PR TITLE
test(wave-4): unit tests for WebSmsWebhook and WebSmsApiServiceCollectionExtension

### DIFF
--- a/tests/WebSmsNet.UnitTests/Configuration/WebSmsApiServiceCollectionExtensionTests.cs
+++ b/tests/WebSmsNet.UnitTests/Configuration/WebSmsApiServiceCollectionExtensionTests.cs
@@ -1,0 +1,150 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Shouldly;
+using WebSmsNet.Abstractions;
+using WebSmsNet.Abstractions.Configuration;
+using WebSmsNet.AspNetCore.Configuration;
+
+namespace WebSmsNet.UnitTests.Configuration;
+
+[TestFixture]
+public class WebSmsApiServiceCollectionExtensionTests
+{
+    [Test]
+    public void AddWebSmsApiClient_RegistersWebSmsApiOptions()
+    {
+        var services = new ServiceCollection();
+
+        services.AddWebSmsApiClient(opt =>
+        {
+            opt.BaseUrl = "https://api.example.com/";
+            opt.AuthenticationType = AuthenticationType.Bearer;
+            opt.AccessToken = "test-token";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<WebSmsApiOptions>>().Value;
+        options.BaseUrl.ShouldBe("https://api.example.com/");
+        options.AuthenticationType.ShouldBe(AuthenticationType.Bearer);
+        options.AccessToken.ShouldBe("test-token");
+    }
+
+    [Test]
+    public void AddWebSmsApiClient_RegistersWebSmsApiConnectionHandlerAsTypedHttpClient()
+    {
+        var services = new ServiceCollection();
+
+        services.AddWebSmsApiClient(opt =>
+        {
+            opt.BaseUrl = "https://api.example.com/";
+            opt.AuthenticationType = AuthenticationType.Bearer;
+            opt.AccessToken = "test-token";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var handler = provider.GetRequiredService<WebSmsApiConnectionHandler>();
+        handler.ShouldNotBeNull();
+    }
+
+    [Test]
+    public void AddWebSmsApiClient_RegistersIWebSmsApiClientAsScoped()
+    {
+        var services = new ServiceCollection();
+
+        services.AddWebSmsApiClient(opt =>
+        {
+            opt.BaseUrl = "https://api.example.com/";
+            opt.AuthenticationType = AuthenticationType.Bearer;
+            opt.AccessToken = "test-token";
+        });
+
+        var descriptor = services.Single(d => d.ServiceType == typeof(IWebSmsApiClient));
+        descriptor.Lifetime.ShouldBe(ServiceLifetime.Scoped);
+    }
+
+    [Test]
+    public void AddWebSmsApiClient_ResolvesIWebSmsApiClient()
+    {
+        var services = new ServiceCollection();
+
+        services.AddWebSmsApiClient(opt =>
+        {
+            opt.BaseUrl = "https://api.example.com/";
+            opt.AuthenticationType = AuthenticationType.Bearer;
+            opt.AccessToken = "test-token";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IWebSmsApiClient>();
+        client.ShouldNotBeNull();
+    }
+
+    [Test]
+    public void AddWebSmsApiClient_ResolvedClientIsWebSmsApiClient()
+    {
+        var services = new ServiceCollection();
+
+        services.AddWebSmsApiClient(opt =>
+        {
+            opt.BaseUrl = "https://api.example.com/";
+            opt.AuthenticationType = AuthenticationType.Bearer;
+            opt.AccessToken = "test-token";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IWebSmsApiClient>();
+        client.ShouldBeOfType<WebSmsApiClient>();
+    }
+
+    [Test]
+    public void AddWebSmsApiClient_ScopedLifetime_DifferentScopesYieldDifferentInstances()
+    {
+        var services = new ServiceCollection();
+
+        services.AddWebSmsApiClient(opt =>
+        {
+            opt.BaseUrl = "https://api.example.com/";
+            opt.AuthenticationType = AuthenticationType.Bearer;
+            opt.AccessToken = "test-token";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        using var scope1 = provider.CreateScope();
+        using var scope2 = provider.CreateScope();
+        var client1 = scope1.ServiceProvider.GetRequiredService<IWebSmsApiClient>();
+        var client2 = scope2.ServiceProvider.GetRequiredService<IWebSmsApiClient>();
+
+        client1.ShouldNotBeSameAs(client2);
+    }
+
+    [Test]
+    public void AddWebSmsApiClient_AppliesOptionsToHttpClient()
+    {
+        var services = new ServiceCollection();
+
+        services.AddWebSmsApiClient(opt =>
+        {
+            opt.BaseUrl = "https://api.example.com/";
+            opt.AuthenticationType = AuthenticationType.Bearer;
+            opt.AccessToken = "test-token";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        Should.NotThrow(() => provider.GetRequiredService<WebSmsApiConnectionHandler>());
+    }
+
+    [Test]
+    public void AddWebSmsApiClient_ReturnsServiceCollectionForChaining()
+    {
+        var services = new ServiceCollection();
+
+        var result = services.AddWebSmsApiClient(opt =>
+        {
+            opt.BaseUrl = "https://api.example.com/";
+            opt.AuthenticationType = AuthenticationType.Bearer;
+            opt.AccessToken = "test-token";
+        });
+
+        result.ShouldBeSameAs(services);
+    }
+}

--- a/tests/WebSmsNet.UnitTests/Helpers/WebSmsWebhookTests.cs
+++ b/tests/WebSmsNet.UnitTests/Helpers/WebSmsWebhookTests.cs
@@ -1,0 +1,332 @@
+using System.Text;
+using System.Text.Json;
+using Shouldly;
+using WebSmsNet.Abstractions.Models;
+using WebSmsNet.Abstractions.Models.Enums;
+using WebSmsNet.AspNetCore.Helpers;
+
+namespace WebSmsNet.UnitTests.Helpers;
+
+[TestFixture]
+public class WebSmsWebhookTests
+{
+    private const string TextWebhookJson = """
+                                           {
+                                               "messageType": "text",
+                                               "notificationId": "02c1d0051949fe70cbfa",
+                                               "senderAddress": "4367612345678",
+                                               "senderAddressType": "international",
+                                               "recipientAddress": "08282709900001",
+                                               "recipientAddressType": "national",
+                                               "textMessageContent": "Hello World"
+                                           }
+                                           """;
+
+    private const string BinaryWebhookJson = """
+                                             {
+                                                 "messageType": "binary",
+                                                 "notificationId": "xyz789",
+                                                 "senderAddress": "4366012345678",
+                                                 "senderAddressType": "international",
+                                                 "recipientAddress": "066012345678",
+                                                 "recipientAddressType": "national",
+                                                 "userDataHeaderPresent": true,
+                                                 "binaryMessageContent": ["AQID", "BAUG"]
+                                             }
+                                             """;
+
+    private const string DeliveryReportWebhookJson = """
+                                                     {
+                                                         "messageType": "deliveryReport",
+                                                         "notificationId": "5280675327899111111",
+                                                         "transferId": "00670eb55d00349e1111",
+                                                         "senderAddress": "41791111111",
+                                                         "deliveryReportMessageStatus": "delivered",
+                                                         "sentOn": "2024-10-15T20:33:02.000+02:00",
+                                                         "deliveredOn": "2024-10-15T20:33:03.000+02:00",
+                                                         "clientMessageId": "11cf996f-c59f-40db-bcff-c8ce03ce3a72"
+                                                     }
+                                                     """;
+
+    [Test]
+    public void Parse_String_TextJson_ReturnsTextRequest()
+    {
+        var result = WebSmsWebhook.Parse(TextWebhookJson);
+
+        result.ShouldBeOfType<WebSmsWebhookRequest.Text>();
+        result.MessageType.ShouldBe(WebhookMessageType.Text);
+        result.NotificationId.ShouldBe("02c1d0051949fe70cbfa");
+        ((WebSmsWebhookRequest.Text)result).TextMessageContent.ShouldBe("Hello World");
+    }
+
+    [Test]
+    public void Parse_String_BinaryJson_ReturnsBinaryRequest()
+    {
+        var result = WebSmsWebhook.Parse(BinaryWebhookJson);
+
+        result.ShouldBeOfType<WebSmsWebhookRequest.Binary>();
+        result.MessageType.ShouldBe(WebhookMessageType.Binary);
+        var binary = (WebSmsWebhookRequest.Binary)result;
+        binary.UserDataHeaderPresent.ShouldBeTrue();
+        binary.BinaryMessageContent.ShouldBe(["AQID", "BAUG"]);
+    }
+
+    [Test]
+    public void Parse_String_DeliveryReportJson_ReturnsDeliveryReportRequest()
+    {
+        var result = WebSmsWebhook.Parse(DeliveryReportWebhookJson);
+
+        result.ShouldBeOfType<WebSmsWebhookRequest.DeliveryReport>();
+        result.MessageType.ShouldBe(WebhookMessageType.DeliveryReport);
+        var report = (WebSmsWebhookRequest.DeliveryReport)result;
+        report.TransferId.ShouldBe("00670eb55d00349e1111");
+        report.DeliveryReportMessageStatus.ShouldBe(DeliveryReportMessageStatus.Delivered);
+        report.ClientMessageId.ShouldBe("11cf996f-c59f-40db-bcff-c8ce03ce3a72");
+    }
+
+    [Test]
+    public void Parse_String_InvalidJson_ThrowsJsonException()
+    {
+        Should.Throw<JsonException>(() => WebSmsWebhook.Parse("{not json"));
+    }
+
+    [Test]
+    public void Parse_String_NullLiteral_ThrowsInvalidOperationException()
+    {
+        var ex = Should.Throw<InvalidOperationException>(() => WebSmsWebhook.Parse("null"));
+        ex.Message.ShouldBe("Failed to deserialize web sms webhook request");
+    }
+
+    [Test]
+    public async Task Parse_Stream_TextJson_ReturnsTextRequest()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(TextWebhookJson));
+
+        var result = await WebSmsWebhook.Parse(stream);
+
+        result.ShouldBeOfType<WebSmsWebhookRequest.Text>();
+        result.NotificationId.ShouldBe("02c1d0051949fe70cbfa");
+        ((WebSmsWebhookRequest.Text)result).TextMessageContent.ShouldBe("Hello World");
+    }
+
+    [Test]
+    public async Task Parse_Stream_RespectsCancellationToken()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(TextWebhookJson));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Should.ThrowAsync<OperationCanceledException>(() =>
+            WebSmsWebhook.Parse(stream, cts.Token));
+    }
+
+    [Test]
+    public void Match_Func_TextRequest_InvokesOnTextHandler()
+    {
+        WebSmsWebhookRequest.Base request = new WebSmsWebhookRequest.Text
+        {
+            MessageType = WebhookMessageType.Text,
+            NotificationId = "test-id",
+            SenderAddress = "4366012345678",
+            SenderAddressType = AddressType.International,
+            RecipientAddress = "066012345678",
+            RecipientAddressType = AddressType.National,
+            TextMessageContent = "Hello"
+        };
+
+        var result = request.Match(
+            onText: _ => 1,
+            onBinary: _ => 2,
+            onDeliveryReport: _ => 3);
+
+        result.ShouldBe(1);
+    }
+
+    [Test]
+    public void Match_Func_BinaryRequest_InvokesOnBinaryHandler()
+    {
+        WebSmsWebhookRequest.Base request = new WebSmsWebhookRequest.Binary
+        {
+            MessageType = WebhookMessageType.Binary,
+            NotificationId = "test-id",
+            SenderAddress = "4366012345678",
+            SenderAddressType = AddressType.International,
+            RecipientAddress = "066012345678",
+            RecipientAddressType = AddressType.National,
+            UserDataHeaderPresent = false,
+            BinaryMessageContent = ["AQID"]
+        };
+
+        var result = request.Match(
+            onText: _ => 1,
+            onBinary: _ => 2,
+            onDeliveryReport: _ => 3);
+
+        result.ShouldBe(2);
+    }
+
+    [Test]
+    public void Match_Func_DeliveryReportRequest_InvokesOnDeliveryReportHandler()
+    {
+        WebSmsWebhookRequest.Base request = new WebSmsWebhookRequest.DeliveryReport
+        {
+            MessageType = WebhookMessageType.DeliveryReport,
+            NotificationId = "test-id",
+            SenderAddress = "4366012345678",
+            TransferId = "transfer1",
+            DeliveryReportMessageStatus = DeliveryReportMessageStatus.Delivered,
+            SentOn = DateTimeOffset.Parse("2024-10-15T20:33:02.000+02:00"),
+            ClientMessageId = "client1"
+        };
+
+        var result = request.Match(
+            onText: _ => 1,
+            onBinary: _ => 2,
+            onDeliveryReport: _ => 3);
+
+        result.ShouldBe(3);
+    }
+
+    [Test]
+    public void Match_Func_UnknownSubtype_ThrowsArgumentOutOfRangeException()
+    {
+        WebSmsWebhookRequest.Base request = new UnknownWebhookRequest
+        {
+            MessageType = WebhookMessageType.Text,
+            NotificationId = "test-id",
+            SenderAddress = "4366012345678"
+        };
+
+        Should.Throw<ArgumentOutOfRangeException>(() => request.Match(
+            onText: _ => 1,
+            onBinary: _ => 2,
+            onDeliveryReport: _ => 3));
+    }
+
+    [Test]
+    public void Match_Action_TextRequest_InvokesOnTextHandler()
+    {
+        WebSmsWebhookRequest.Base request = new WebSmsWebhookRequest.Text
+        {
+            MessageType = WebhookMessageType.Text,
+            NotificationId = "test-id",
+            SenderAddress = "4366012345678",
+            SenderAddressType = AddressType.International,
+            RecipientAddress = "066012345678",
+            RecipientAddressType = AddressType.National,
+            TextMessageContent = "Hello"
+        };
+        var textCount = 0;
+        var binaryCount = 0;
+        var deliveryReportCount = 0;
+
+        request.Match(
+            onText: _ => textCount++,
+            onBinary: _ => binaryCount++,
+            onDeliveryReport: _ => deliveryReportCount++);
+
+        textCount.ShouldBe(1);
+        binaryCount.ShouldBe(0);
+        deliveryReportCount.ShouldBe(0);
+    }
+
+    [Test]
+    public void Match_Action_BinaryRequest_InvokesOnBinaryHandler()
+    {
+        WebSmsWebhookRequest.Base request = new WebSmsWebhookRequest.Binary
+        {
+            MessageType = WebhookMessageType.Binary,
+            NotificationId = "test-id",
+            SenderAddress = "4366012345678",
+            SenderAddressType = AddressType.International,
+            RecipientAddress = "066012345678",
+            RecipientAddressType = AddressType.National,
+            UserDataHeaderPresent = false,
+            BinaryMessageContent = ["AQID"]
+        };
+        var textCount = 0;
+        var binaryCount = 0;
+        var deliveryReportCount = 0;
+
+        request.Match(
+            onText: _ => textCount++,
+            onBinary: _ => binaryCount++,
+            onDeliveryReport: _ => deliveryReportCount++);
+
+        textCount.ShouldBe(0);
+        binaryCount.ShouldBe(1);
+        deliveryReportCount.ShouldBe(0);
+    }
+
+    [Test]
+    public void Match_Action_DeliveryReportRequest_InvokesOnDeliveryReportHandler()
+    {
+        WebSmsWebhookRequest.Base request = new WebSmsWebhookRequest.DeliveryReport
+        {
+            MessageType = WebhookMessageType.DeliveryReport,
+            NotificationId = "test-id",
+            SenderAddress = "4366012345678",
+            TransferId = "transfer1",
+            DeliveryReportMessageStatus = DeliveryReportMessageStatus.Delivered,
+            SentOn = DateTimeOffset.Parse("2024-10-15T20:33:02.000+02:00"),
+            ClientMessageId = "client1"
+        };
+        var textCount = 0;
+        var binaryCount = 0;
+        var deliveryReportCount = 0;
+
+        request.Match(
+            onText: _ => textCount++,
+            onBinary: _ => binaryCount++,
+            onDeliveryReport: _ => deliveryReportCount++);
+
+        textCount.ShouldBe(0);
+        binaryCount.ShouldBe(0);
+        deliveryReportCount.ShouldBe(1);
+    }
+
+    [Test]
+    public void Match_Action_UnknownSubtype_ThrowsArgumentOutOfRangeException()
+    {
+        WebSmsWebhookRequest.Base request = new UnknownWebhookRequest
+        {
+            MessageType = WebhookMessageType.Text,
+            NotificationId = "test-id",
+            SenderAddress = "4366012345678"
+        };
+
+        Should.Throw<ArgumentOutOfRangeException>(() => request.Match(
+            onText: _ => { },
+            onBinary: _ => { },
+            onDeliveryReport: _ => { }));
+    }
+
+    [Test]
+    public void CreateOkResponse_ReturnsResponseWithStatusCodeOkAndOkMessage()
+    {
+        var response = WebSmsWebhook.CreateOkResponse();
+
+        response.StatusCode.ShouldBe(WebSmsStatusCode.Ok);
+        response.StatusMessage.ShouldBe("OK");
+    }
+
+    [Test]
+    public void CreateErrorResponse_ReturnsResponseWithInternalErrorAndProvidedMessage()
+    {
+        var response = WebSmsWebhook.CreateErrorResponse("boom");
+
+        response.StatusCode.ShouldBe(WebSmsStatusCode.InternalError);
+        response.StatusMessage.ShouldBe("boom");
+    }
+
+    [Test]
+    public void CreateErrorResponse_NullMessage_PropagatesNull()
+    {
+        var response = WebSmsWebhook.CreateErrorResponse(null!);
+
+        response.StatusCode.ShouldBe(WebSmsStatusCode.InternalError);
+        response.StatusMessage.ShouldBeNull();
+    }
+
+    private sealed class UnknownWebhookRequest : WebSmsWebhookRequest.Base;
+}


### PR DESCRIPTION
## Summary

Closes #7 — Wave 4 unit tests for the ASP.NET Core helpers as part of the Test Coverage Roadmap (#3).

### Changes
- **`tests/WebSmsNet.UnitTests/Helpers/WebSmsWebhookTests.cs`** — 18 tests covering `WebSmsWebhook`:
  - Both `Parse` overloads (string and Stream)
  - Both `Match` overloads (Func and Action) for all webhook types: Text, Binary, DeliveryReport, unknown (throws)
  - `CreateOkResponse` and `CreateErrorResponse` factories
- **`tests/WebSmsNet.UnitTests/Configuration/WebSmsApiServiceCollectionExtensionTests.cs`** — 8 tests covering `AddWebSmsApiClient`:
  - `WebSmsApiOptions` registration with value propagation
  - `WebSmsApiConnectionHandler` typed-client resolution
  - `IWebSmsApiClient` scoped lifetime (descriptor inspection + two-scope instance comparison)
  - Fluent return value

### Results
| Metric | Value |
|--------|-------|
| Tests added | 26 new (79 total pass) |
| Production files modified | None |
| NuGet packages added | None |
| Verification verdict | APPROVED |

### Notes
- NSubstitute deliberately omitted — neither class has collaborators that benefit from mocking; `MemoryStream` and a real `ServiceCollection` cover all paths
- Existing webhook/DI tests in `MessagingTests.cs` intentionally left in place (scope discipline)
- No `.editorconfig` in repo; `jb cleanupcode` skipped per project guidance; style matched by hand

## Test plan
- [x] `dotnet build` — clean, zero warnings
- [x] `dotnet test WebSmsNet.UnitTests` — 79 passed, 0 failed
- [x] Verification agent: VERDICT APPROVED
- [x] All acceptance criteria from #7 met

🤖 Generated with [Claude Code](https://claude.com/claude-code)